### PR TITLE
feat: version key is no longer necessary

### DIFF
--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   ffc-template-node:
     command: npm run start:debug

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # This override file should be used when running this service in isolation
 # to provide dependencies and expose ports for local testing
 

--- a/docker-compose.test.debug.yaml
+++ b/docker-compose.test.debug.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   ffc-template-node:
     command: npm run test:debug

--- a/docker-compose.test.watch.yaml
+++ b/docker-compose.test.watch.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   ffc-template-node:
     command: >

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # This override file should be used when running automated tests so
 # that test output is saved to the host
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   ffc-template-node:
     build:


### PR DESCRIPTION
Top level `version` key no longer required - [source](https://docs.docker.com/compose/compose-file/#version-top-level-element).