### PR TITLE
Add missing whitespace (helm/ffc-template-node/templates/_container.yaml)

### DIFF
--- a/helm/ffc-template-node/templates/_container.yaml
+++ b/helm/ffc-template-node/templates/_container.yaml
@@ -1,6 +1,6 @@
 {{- define "ffc-template-node.container" -}}
-livenessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.livenessProbe) | nindent 4}}
-readinessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.readinessProbe) | nindent 4}}
+livenessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.livenessProbe) | nindent 4 }}
+readinessProbe: {{ include "ffc-helm-library.http-get-probe" (list . .Values.readinessProbe) | nindent 4 }}
 ports:
 - containerPort: {{ .Values.container.port }}
 {{- end -}}


### PR DESCRIPTION
Missing whitespace from `_container.yaml` in helm folder causes SonarCloud quality gate to fail. As a result, SonarCloud itself suggests adding in the missing whitespace on lines 2 and 3 in the `_container.yaml` file (screenshot below illustrates this where the `ffc-template-node` template was used to create a service called `fcp-fd-messages`). Full path to file: [`helm/ffc-template-node/templates/_container.yaml`](https://github.com/DEFRA/ffc-template-node/pull/27/commits/f9c52a3244fe22ad0ea23a37e401e85b6bde4abe).

![image](https://github.com/user-attachments/assets/e06cb4eb-991b-452b-890d-9c90c8efc7c6)